### PR TITLE
fix(heatmap link): encode feature name to prevent URL truncation

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -170,7 +170,8 @@
                                 "<a href='" + feature.properties.url + "' target='_blank' >website</a>  " +
                                 "<a href='" + feature.properties.source + "' target='_blank' >source</a>  "
                             if (type == 'api') {
-                                html += "<a href='/heatmap/show.php?id=" + encodeURIComponent(feature.properties.name) + "' target='_blank' >heatmap</a>"
+                                const encodedName = encodeURIComponent(feature.properties.name);
+                                html += `<a href="/heatmap/show.php?id=${encodedName}" target="_blank">heatmap</a>`;
                             }
                             layer.bindPopup(html).addTo(geolayer);
                         };

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -170,7 +170,7 @@
                                 "<a href='" + feature.properties.url + "' target='_blank' >website</a>  " +
                                 "<a href='" + feature.properties.source + "' target='_blank' >source</a>  "
                             if (type == 'api') {
-                                html += "<a href='/heatmap/show.php?id=" + feature.properties.name + "' target='_blank' >heatmap</a>"
+                                html += "<a href='/heatmap/show.php?id=" + encodeURIComponent(feature.properties.name) + "' target='_blank' >heatmap</a>"
                             }
                             layer.bindPopup(html).addTo(geolayer);
                         };


### PR DESCRIPTION
# Bug Fix: Resolve URL truncation in Leaflet popups from special characters

### Problem

When a map feature's name contains a single quote, for example, **"Metro Olografix L'Aquila"**, the Leaflet popup hyperlink breaks. Because the HTML string was constructed using single quotes (`href='...'`), the apostrophe in the data acted as a closing quote for the attribute, truncating the URL and corrupting the DOM structure.

### Solution

Updated the template string inside the API check to utilize standard double quotes for HTML attributes and wrapped the query value in `encodeURIComponent()`.

```javascript
if (type == 'api') {
    const encodedName = encodeURIComponent(feature.properties.name);
    html += `<a href="/heatmap/show.php?id=${encodedName}" target="_blank">heatmap</a>`;
}

```

<img width="549" height="458" alt="image" src="https://github.com/user-attachments/assets/2ad18fd8-83fe-4a1e-86c0-9377a0e9d263" />
